### PR TITLE
Fix link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Preliminary Draft
 
 The BHP text and all its additional features are made available under a [CC-BY-SA License](http://creativecommons.org/licenses/by-sa/4.0/).
 
-Consult the BHP Introduction (https://github.com/greekcntr/BHP/blob/master/BHP_Introduction.pdf) and CNTR Project Description (https://greekcntr.org/downloads/project.pdf) for more information.
+Consult the BHP Introduction (https://github.com/greekcntr/BHP/blob/master/BHP_Introduction.pdf) and CNTR Project Description (https://www.greekcntr.org/resources/technical.pdf) for more information.
 
 Citation
 -----


### PR DESCRIPTION
I believe the stale link https://greekcntr.org/downloads/project.pdf should
be updated to https://www.greekcntr.org/resources/technical.pdf.